### PR TITLE
docs: remove deprecated reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Head on to the official community forum: [http://forum.quasar-framework.org](htt
 
 * [Quasar Framework](https://github.com/rstoenescu/quasar-framework)
 * [Quasar CLI](https://github.com/rstoenescu/quasar-cli)
-* [Quasar App Templates](https://github.com/rstoenescu/quasar-templates)
 * [Quasar Play App](https://github.com/rstoenescu/quasar-play)
 
 ## Contributing


### PR DESCRIPTION
Removing reference to deprecated quasar-templates repo