### PR TITLE
Generating a production build fails for an electron app when NODE_ENV set to development

### DIFF
--- a/template/build/script.build.js
+++ b/template/build/script.build.js
@@ -10,7 +10,7 @@ var
   webpackConfig = require('./webpack.prod.conf'),
   targetPath = path.join(__dirname, '../dist')
 
-console.log(' Built files are meant to be served over an HTTP server.')		
+console.log(' Built files are meant to be served over an HTTP server.')
 console.log(' Opening index.html over file:// won\'t work.\n')
 
 console.log(' WARNING!'.bold)

--- a/template/build/script.build.js
+++ b/template/build/script.build.js
@@ -10,9 +10,6 @@ var
   webpackConfig = require('./webpack.prod.conf'),
   targetPath = path.join(__dirname, '../dist')
 
-console.log(' Built files are meant to be served over an HTTP server.')
-console.log(' Opening index.html over file:// won\'t work.\n')
-
 console.log(' WARNING!'.bold)
 console.log(' Do NOT use VueRouter\'s "history" mode if')
 console.log(' building for Cordova or Electron.\n')

--- a/template/build/script.build.js
+++ b/template/build/script.build.js
@@ -10,6 +10,9 @@ var
   webpackConfig = require('./webpack.prod.conf'),
   targetPath = path.join(__dirname, '../dist')
 
+console.log(' Built files are meant to be served over an HTTP server.')		
+console.log(' Opening index.html over file:// won\'t work.\n')
+
 console.log(' WARNING!'.bold)
 console.log(' Do NOT use VueRouter\'s "history" mode if')
 console.log(' building for Cordova or Electron.\n')

--- a/template/build/script.build.js
+++ b/template/build/script.build.js
@@ -1,6 +1,4 @@
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'production'
-}
+process.env.NODE_ENV = 'production'
 
 require('colors')
 


### PR DESCRIPTION
Electron app serves the files from relative path. When NODE_ENV is not set properly, the `publicPath` on `config/index.js` is set to `/`. Due to this, the packaged app can't find the assets.