### PR TITLE
Added node-config to manage client-side config files

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -1,5 +1,6 @@
 var
   path = require('path'),
+  fs = require('fs'),
   webpack = require('webpack'),
   config = require('../config'),
   cssUtils = require('./css-utils'),
@@ -11,11 +12,14 @@ var
     (env.dev && config.dev.cssSourceMap) ||
     (env.prod && config.build.productionSourceMap)
 
+// Load config based on current NODE_ENV
+var clientConfig = require('config')
+
 function resolve (dir) {
   return path.join(__dirname, '..', dir)
 }
 
-module.exports = {
+var webpackConfig = {
   entry: {
     app: './src/main.js'
   },
@@ -113,3 +117,9 @@ module.exports = {
     hints: false
   }
 }
+
+// This will take the config based on the current NODE_ENV and save it to 'config/client-config.json'
+// A webpack alias will then integrate that file into the client build.
+fs.writeFileSync(path.join('config', 'client-config.json'), JSON.stringify(clientConfig))
+
+module.exports = webpackConfig

--- a/template/config/default.js
+++ b/template/config/default.js
@@ -1,0 +1,3 @@
+module.exports = {
+    mode: process.env.NODE_ENV
+}

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -6,7 +6,8 @@ module.exports = {
     quasar: path.resolve(__dirname, '../node_modules/quasar-framework/'),
     src: path.resolve(__dirname, '../src'),
     assets: path.resolve(__dirname, '../src/assets'),
-    components: path.resolve(__dirname, '../src/components')
+    components: path.resolve(__dirname, '../src/components'),
+    config: path.resolve(__dirname, './client-config.json')
   },
 
   // Progress Bar Webpack plugin format

--- a/template/package.json
+++ b/template/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.0.0",
+    "config": "^1.26.1",
     "fastclick": "^1.0.6",
     "material-design-icons": "^3.0.1",
     "moment": "^2.15.0",

--- a/template/src/components/Index.vue
+++ b/template/src/components/Index.vue
@@ -2,7 +2,7 @@
   <q-layout>
     <div slot="header" class="toolbar">
       <q-toolbar-title :padding="0">
-        Quasar Framework v{{$q.version}}
+        Quasar Framework v{{$q.version}} - {{mode}}
       </q-toolbar-title>
     </div>
 
@@ -29,6 +29,7 @@
 var moveForce = 30
 var rotateForce = 40
 
+import config from 'config'
 import { Utils } from 'quasar'
 
 export default {
@@ -37,7 +38,8 @@ export default {
       moveX: 0,
       moveY: 0,
       rotateY: 0,
-      rotateX: 0
+      rotateX: 0,
+      mode: config.mode
     }
   },
   computed: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

the PR's description:

It is usually mandatory  to manage different config files for different deployment environments in a production app. Although there is already a **config** folder in the template it is mainly related to build configuration parameters and should not be exposed on the client-side. So it would be great to propose something dedicated to **client-side** configuration parameters such as external service URLs,  etc. On the server-side [node-config](https://github.com/lorenwest/node-config) has proven to be a great tool to manage configuration files, and using WebPack we could rely on it as well for the client side as proposed in this PR.