### PR TITLE
Fall back to accelerometer data for tilting if gyroscope is not available

### DIFF
--- a/template/src/components/Index.vue
+++ b/template/src/components/Index.vue
@@ -16,7 +16,7 @@
         <div class="logo" :style="position">
           <img src="~assets/quasar-logo.png">
           <p class="caption text-center">
-            <span v-if="orienting">Tilt your device.</span>
+            <span v-if="orienting || rotating">Tilt your device.</span>
             <template v-else>
               <span class="desktop-only">Move your mouse.</span>
               <span class="touch-only">Touch screen and move.</span>
@@ -29,15 +29,28 @@
 </template>
 
 <script>
-var moveForce = 30
-var rotateForce = 40
+const moveForce = 30
+const rotateForce = 40
+const RAD_TO_DEG = 180 / Math.PI
 
 import { Utils, Platform } from 'quasar'
+
+function getRotationFromAccel (accelX, accelY, accelZ) {
+  /* Reference: http://stackoverflow.com/questions/3755059/3d-accelerometer-calculate-the-orientation#answer-30195572 */
+  const sign = accelZ > 0 ? 1 : -1
+  const miu = 0.001
+
+  return {
+    roll: Math.atan2(accelY, sign * Math.sqrt(Math.pow(accelZ, 2) + miu * Math.pow(accelX, 2))) * RAD_TO_DEG,
+    pitch: -Math.atan2(accelX, Math.sqrt(Math.pow(accelY, 2) + Math.pow(accelZ, 2))) * RAD_TO_DEG
+  }
+}
 
 export default {
   data () {
     return {
       orienting: window.DeviceOrientationEvent && !Platform.is.desktop,
+      rotating: window.DeviceMotionEvent && !Platform.is.desktop,
       moveX: 0,
       moveY: 0,
       rotateY: 0,
@@ -46,7 +59,7 @@ export default {
   },
   computed: {
     position () {
-      let transform = `rotateX(${this.rotateX}deg) rotateY(${this.rotateY}deg)`
+      const transform = `rotateX(${this.rotateX}deg) rotateY(${this.rotateY}deg)`
       return {
         top: this.moveY + 'px',
         left: this.moveX + 'px',
@@ -68,15 +81,45 @@ export default {
       this.rotateY = (left / width * rotateForce * 2) - rotateForce
       this.rotateX = -((top / height * rotateForce * 2) - rotateForce)
     },
+    rotate (evt) {
+      if (evt.rotationRate &&
+          evt.rotationRate.beta !== null &&
+          evt.rotationRate.gamma !== null) {
+        this.rotateX = evt.rotationRate.beta * 0.7
+        this.rotateY = evt.rotationRate.gamma * -0.7
+      }
+      else {
+        /* evt.acceleration may be null in some cases, so we'll fall back
+           to evt.accelerationIncludingGravity */
+        const accelX = evt.acceleration.x || evt.accelerationIncludingGravity.x
+        const accelY = evt.acceleration.y || evt.accelerationIncludingGravity.y
+        const accelZ = evt.acceleration.z || evt.accelerationIncludingGravity.z - 9.81
+
+        const rotation = getRotationFromAccel(accelX, accelY, accelZ)
+        this.rotateX = rotation.roll * 0.7
+        this.rotateY = rotation.pitch * -0.7
+      }
+    },
     orient (evt) {
-      this.rotateX = evt.beta * 0.7
-      this.rotateY = evt.gamma * -0.7
+      if (evt.beta === null || evt.gamma === null) {
+        window.removeEventListener('deviceorientation', this.orient, false)
+        this.orienting = false
+
+        window.addEventListener('devicemotion', this.rotate, false)
+      }
+      else {
+        this.rotateX = evt.beta * 0.7
+        this.rotateY = evt.gamma * -0.7
+      }
     }
   },
   mounted () {
     this.$nextTick(() => {
       if (this.orienting) {
         window.addEventListener('deviceorientation', this.orient, false)
+      }
+      else if (this.rotating) {
+        window.addEventListener('devicemove', this.rotate, false)
       }
       else {
         document.addEventListener('mousemove', this.move)
@@ -87,6 +130,9 @@ export default {
     if (this.orienting) {
       window.removeEventListener('deviceorientation', this.orient, false)
     }
+    else if (this.rotating) {
+      window.removeEventListener('devicemove', this.rotate, false)
+    }
     else {
       document.removeEventListener('mousemove', this.move)
     }
@@ -94,7 +140,7 @@ export default {
 }
 </script>
 
-<style lang="styl">
+<style lang="stylus">
 .logo-container
   width 192px
   height 268px


### PR DESCRIPTION
Current Quasar template tilting effect may fail on some low-end mobile devices due to a "false positive" about `DeviceOrientationEvent`. Even if the device does **not** have a gyroscope, `window.DeviceOrientationEvent` may be still available, although their Euler angles are always `null`.

This PR goes further on checking for device orientation support, falling back to accelerometer data (got from `DeviceMotionEvent`) to calculate current pitch & roll, following references like [this one](https://www.dfrobot.com/wiki/index.php/How_to_Use_a_Three-Axis_Accelerometer_for_Tilt_Sensing).

Tested on a Motorola Moto E 1st gen (codename "condor") mobile phone