### PR TITLE
Limit Vue version to 2.3.X series until inject bug is fixed

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,7 +13,7 @@
     "babel-runtime": "^6.0.0",
     "quasar-extras": "0.x",
     "quasar-framework": "git+https://git@github.com/quasarframework/quasar-edge.git",
-    "vue": "^2.3.0",
+    "vue": "~2.3.0",
     "vue-router": "^2.0.0"
   },
   "devDependencies": {
@@ -56,7 +56,7 @@
     "url-loader": "^0.5.7",
     "vue-loader": "^12.0.2",
     "vue-style-loader": "^3.0.1",
-    "vue-template-compiler": "^2.3.0",
+    "vue-template-compiler": "~2.3.0",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.8.4",
     "webpack-hot-middleware": "^2.17.0",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Temporary fix till upstream is fixed (vuejs/vue#6093)