### PR TITLE
Adds docker-compose to quasar default template.

### DIFF
--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:8-alpine
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+RUN apk add --update git && rm -rf /tmp/* /var/cache/apk/*
+RUN npm install -g cordova quasar-cli
+RUN cordova --version
+
+WORKDIR /var/www
+
+ENV NODE_ENV=development
+COPY package.json /var/wwwpackage.json
+RUN npm install
+
+COPY . /var/www
+
+EXPOSE 8080
+VOLUME /var/www
+
+CMD ["quasar", "dev"]

--- a/template/README.md
+++ b/template/README.md
@@ -2,9 +2,34 @@
 
 > A Quasar project
 
-## Build Setup
+## Develop using docker
+This will allow you to develop the quasar app in a docker container.
+
+Open two terminals pointing to the same project root. Use one to run `docker-compose up` and another to ssh into the running container to run wanted commands with `npm run bash`
 
 ``` bash
+
+# Run docker-compose in one terminal
+$ docker-compose up
+
+# ssh into the running container
+$ npm run bash
+```
+
+To work with `quasar dev --play` you must use manually reference the ip port of your computer instead of the one used by the docker container.
+
+``` bash
+
+# On a mac
+$ ifconfig
+```
+
+## Develop using local environment
+
+### Build Setup
+
+``` bash
+
 # install dependencies
 $ npm install
 

--- a/template/build/script.build.js
+++ b/template/build/script.build.js
@@ -10,6 +10,7 @@ var
   config = require('../config'),
   webpack = require('webpack'),
   webpackConfig = require('./webpack.prod.conf'),
+  renderSSR = require('./script.ssr'),
   targetPath = path.join(__dirname, '../dist')
 
 console.log(' WARNING!'.bold)
@@ -29,6 +30,12 @@ function finalize () {
 
   console.log(' Built files are meant to be served over an HTTP server.'.bold)
   console.log(' Opening index.html over file:// won\'t work.'.bold)
+}
+
+// Compile SSR
+if (config.renderSSR) {
+  const renderSSR = require('./script.ssr')
+  renderSSR({ watch: false })
 }
 
 webpack(webpackConfig, function (err, stats) {

--- a/template/build/script.dev.js
+++ b/template/build/script.dev.js
@@ -21,6 +21,12 @@ if (config.dev.openBrowser) {
   console.log(' Browser will open when build is ready.\n')
 }
 
+// Compile SSR
+if (config.renderSSR) {
+  const renderSSR = require('./script.ssr')
+  renderSSR({ watch: true })
+}
+
 var compiler = webpack(webpackConfig)
 
 // Define HTTP proxies to your custom API backend

--- a/template/build/script.ssr.js
+++ b/template/build/script.ssr.js
@@ -1,0 +1,27 @@
+var
+  webpack = require('webpack'),
+  webpackSSRConfig = require('./webpack.ssr.conf')
+
+// Compile SSR
+module.exports = function renderSSRFile (overrideOptions) {
+
+  const config = Object.assign(
+    {}, webpackSSRConfig, overrideOptions
+  )
+
+  webpack(config, function (err, stats) {
+    if (err) throw err
+
+    process.stdout.write(stats.toString({
+      colors: true,
+      modules: false,
+      children: false,
+      chunks: false,
+      chunkModules: false
+    }) + '\n')
+
+    if (stats.hasErrors()) {
+      process.exit(1)
+    }
+  })
+}

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -44,7 +44,7 @@ module.exports = merge(baseWebpackConfig, {
       minify: {
         removeComments: true,
         collapseWhitespace: true,
-        removeAttributeQuotes: true
+        removeAttributeQuotes: false
         // more options:
         // https://github.com/kangax/html-minifier#options-quick-reference
       },

--- a/template/build/webpack.ssr.conf.js
+++ b/template/build/webpack.ssr.conf.js
@@ -1,0 +1,81 @@
+var 
+  config = require('../config'),
+  webpack = require('webpack'),
+  merge = require('webpack-merge'),
+  cssUtils = require('./css-utils'),
+  { cloneDeep } = require('lodash'),
+  baseWebpackConfig = require('./webpack.base.conf'),
+  path = require('path'),
+  FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
+
+const projectRoot = path.resolve(__dirname, '../')
+const serverFolder = config.serverFolder || 'api'
+const baseConfig = cloneDeep(baseWebpackConfig)
+
+module.exports = Object.assign({}, baseConfig, {
+  target: 'node',
+  watch: true,
+  devServer: undefined,
+  devtool: '#cheap-module-eval-source-map',
+  entry: [
+    path.resolve(__dirname, `../${serverFolder}/vue-server-side-rendering.js`)
+  ],
+  output: {
+    libraryTarget: 'commonjs2',
+    path: path.resolve(__dirname, `../${serverFolder}/src/ssr/`),
+    filename: 'compiled-ssr.js',
+  },
+  module: {
+    rules: cssUtils.styleRules({
+      sourceMap: config.dev.cssSourceMap,
+      postcss: true
+    }).concat([
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: projectRoot,
+        exclude: /node_modules/
+      },
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+        options: {
+          postcss: cssUtils.postcss,
+          loaders: merge({js: 'babel-loader'}, cssUtils.styleLoaders({
+            sourceMap: false,
+            extract: false
+          }))
+        }
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
+        loader: 'url-loader',
+        options: {
+          limit: 10000,
+          name: 'img/[name].[hash:7].[ext]'
+        }
+      },
+      {
+        test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
+        loader: 'url-loader',
+        options: {
+          limit: 10000,
+          name: 'fonts/[name].[hash:7].[ext]'
+        }
+      }
+    ])
+  },
+  plugins: baseConfig.plugins.concat([
+    new webpack.NoEmitOnErrorsPlugin(),
+    new FriendlyErrorsPlugin({
+      clearConsole: config.dev.clearConsoleOnRebuild
+    })
+  ]),
+  performance: {
+    hints: false
+  }
+})

--- a/template/config/index.js
+++ b/template/config/index.js
@@ -17,6 +17,9 @@ module.exports = {
   // Default theme to build with ('ios' or 'mat')
   defaultTheme: 'mat',
 
+  serverFolder: 'api',
+  renderSSR: false,
+
   build: {
     env: require('./prod.env'),
     publicPath: '',

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    build: .
+    container_name: 'quasar-dev'
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/var/www/:rw
+      - /var/www/node_modules

--- a/template/package.json
+++ b/template/package.json
@@ -7,6 +7,7 @@
     "clean": "node build/script.clean.js",
     "dev": "node build/script.dev.js",
     "build": "node build/script.build.js",
+    "bash": "docker exec -it quasar-dev bash",
     "lint": "eslint --ext .js,.vue src"
   },
   "dependencies": {


### PR DESCRIPTION
Adds an optional ability to develop your app in a docker container using the default 8080 port. `quasar dev --play` isn't working in this configuration, you must manually add your computers ip port in the play app. Some people prefer to do their development in containers to keep things isolated and portable, so other developers running the project don't have to install cordova, quasar-cli, or node.

_NOTE: This is not a final pull request, this is a sample_

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
