### PR TITLE
Should not purify 'bg-*' and 'text-*' classes

### DIFF
--- a/template/build/css-utils.js
+++ b/template/build/css-utils.js
@@ -73,8 +73,9 @@ module.exports.purify = function(cb) {
 
   Promise.all(css.map(function (file) {
     return new Promise(function (resolve) {
-      console.log('\n Purifying ' + path.relative(path.join(__dirname, '../dist'), file).bold + '...')
-      purify(js, [file], {minify: true}, function (purified) {
+      var notPurifiedClass = ['*bg-*', '*text-*']
+      console.log('\n Purifying ' + path.relative(path.join(__dirname, '../dist'), file, ' but not classes ', notPurifiedClass).bold + '...')
+      purify(js, [file], {minify: true,  whitelist: notPurifiedClass}, function (purified) {
         var oldSize = fs.statSync(file).size
         fs.writeFileSync(file, purified)
         var newSize = fs.statSync(file).size


### PR DESCRIPTION
Using variables in some ways to set the color (or bg-color) is not reconized by `purifycss` even if they try to thing the more crazy things [https://github.com/purifycss/purifycss#detecting-the-use-of-button-active-1]
So, always adding colors in the final packaging could be great for dev more crazy than puryfyccss's team :o) or people using color as functional feature....

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
