### PR TITLE
Fix building error ES6 by replacing UglifyJS by UglifyES.

### DIFF
--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -5,7 +5,8 @@ const
   ExtractTextPlugin = require('extract-text-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin'),
-  CopyWebpackPlugin = require('copy-webpack-plugin')
+  CopyWebpackPlugin = require('copy-webpack-plugin'),
+  UglifyJSPlugin = require('uglifyjs-webpack-plugin')
 
 const
   config = require('../config'),
@@ -86,12 +87,7 @@ const webpackConfig = merge(baseWebpackConfig, {
 
 if (!config.build.debug) {
   webpackConfig.plugins.push(
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      },
-      sourceMap: config.build.debug
-    })
+    new UglifyJSPlugin()
   )
   webpackConfig.plugins.push(
     // Compress extracted CSS. We are using this plugin so that possible

--- a/template/package.json
+++ b/template/package.json
@@ -59,6 +59,7 @@
     "shelljs": "^0.7.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
+	"uglifyjs-webpack-plugin": "^1.0.1",
     "url-loader": "^0.5.8",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.0.3",

--- a/template/package.json
+++ b/template/package.json
@@ -59,7 +59,7 @@
     "shelljs": "^0.7.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
-	"uglifyjs-webpack-plugin": "^1.0.1",
+    "uglifyjs-webpack-plugin": "^1.0.1",
     "url-loader": "^0.5.8",
     "vue-loader": "^13.3.0",
     "vue-style-loader": "^3.0.3",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

From the test I've done, I see not breaking changes. However with the old webpack UglifyJS pluging I was no longer able to build the application as I was always getting the same error
```
ERROR in static/js/app.xxxxx.js from UglifyJs
Unexpected token: operator (>)
```
This is well explains here https://stackoverflow.com/questions/43888474/unexpected-token-operator-from-uglifyjs

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I submitted to the v0,15-wip branch instead of dev branch as I'm now using the quasar-future v.0.15.
